### PR TITLE
feat: provide basic cache and registry configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,22 @@ const metadata = await getLatestVersion('vite')
 console.log(metadata.version) // 5.3.2
 ```
 
+## Configuration
+
+The tool does not require any preliminary configuration to work, but you can override some default parameters through [environment variables or .env files](https://nitro.unjs.io/guide/configuration). The main ones:
+
+| Option                | Description                      | Default                                |
+|-----------------------|----------------------------------|----------------------------------------|
+| `PORT`                | Port to listen on                | `3000`                                 |
+| `HOST`                | Host to serve                    |                                        |
+| `REPO_URL`            | Code reposotory URL              | https://github.com/antfu/fast-npm-meta |
+| `CACHE_TIMEOUT`       | Cache timeout in ms              | `900000` (15m)                         |
+| `CACHE_TIMEOUT_FORCE` | Cache timeout for forced updates | `30000` (30s)                          |
+| `REGISTRY_URL`        | NPM registry URL                 | https://registry.npmjs.org             |
+| `REGISTRY_USER_AGENT` | User agent for NPM registry requests | `get-npm-meta`                         |
+
+For more information, follow [the official Nitro guides](https://nitro.unjs.io/deploy/runtimes/node#environment-variables).
+
 ## Sponsors
 
 <p align="center">

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "bumpp": "^9.4.1",
     "eslint": "^9.6.0",
     "esno": "^4.7.0",
-    "fast-glob": "^3.3.2",
     "lint-staged": "^15.2.7",
     "rimraf": "^5.0.7",
     "simple-git-hooks": "^2.11.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,9 +29,6 @@ importers:
       esno:
         specifier: ^4.7.0
         version: 4.7.0
-      fast-glob:
-        specifier: ^3.3.2
-        version: 3.3.2
       lint-staged:
         specifier: ^15.2.7
         version: 15.2.7

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,11 +1,10 @@
 #!/usr/bin/env zx
 
 import { versionBump } from 'bumpp'
-import glob from 'fast-glob'
-import { $ } from 'zx'
+import { $, glob } from 'zx'
 
 try {
-  const packages = await glob(['package.json', 'server/package.json', 'package/package.json'])
+  const packages = await glob(['package.json', '*/package.json'])
 
   console.log('Bumping versions in packages:', packages.join(', '), '\n')
 

--- a/server/nitro.config.ts
+++ b/server/nitro.config.ts
@@ -17,6 +17,10 @@ export default defineNitroConfig({
       repoUrl,
       revision,
       deployTime: new Date().toISOString(),
+      cacheTimeout: '',
+      cacheTimeoutForce: '',
+      registryUrl: '',
+      registryUserAgent: '',
     },
   },
 })


### PR DESCRIPTION
This PR brings cache timeouts and registry configuration via env:

* `cacheTimeout`
* `cacheTimeoutForce`
* `registryUrl`
* `registryUserAgent`

```bash
NITRO_REGISTRY_URL='https://registry.yarnpkg.com/' 
```