### PR TITLE
feat: add new utility `getRegistry`

### DIFF
--- a/package/build.config.ts
+++ b/package/build.config.ts
@@ -3,6 +3,7 @@ import { defineBuildConfig } from 'unbuild'
 export default defineBuildConfig({
   entries: [
     'src/index',
+    'src/registry',
   ],
   declaration: true,
   clean: true,

--- a/package/package.json
+++ b/package/package.json
@@ -19,6 +19,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
+    },
+    "./registry": {
+      "types": "./dist/registry.d.ts",
+      "import": "./dist/registry.mjs",
+      "require": "./dist/registry.cjs"
     }
   },
   "main": "./dist/index.mjs",

--- a/package/src/registry.ts
+++ b/package/src/registry.ts
@@ -1,0 +1,19 @@
+import { execSync } from 'node:child_process'
+
+/**
+ * Get the npm registry URL.
+ *
+ * @param scope - scope of package
+ * @returns registry URL
+ */
+export function getRegistry(scope?: string) {
+  const defaultRegistry = execSync('npm config get registry').toString().trim()
+
+  if (scope) {
+    scope = scope.replace(/^@?/, '@')
+    const scopeRegistry = execSync(`npm config get ${scope}:registry`).toString().trim()
+    return scopeRegistry || defaultRegistry
+  }
+
+  return defaultRegistry
+}


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR introduces a new utility `getRegistry` to obtain the current registry URL using `npm config get registry`.

I placed it in a separate exports `./registry`, because it depends on `node:child_process`, whereas others do not rely on the Node environment.

### Linked Issues

resolves #9

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
