### PR TITLE
refactor: improve api result types

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,11 @@
     "build:server": "pnpm -C server run build",
     "dev": "pnpm -C server run dev",
     "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "prepublishOnly": "nr build",
     "release": "tsx scripts/release.ts",
     "start": "tsx src/index.ts",
-    "test": "vitest",
+    "test": "vitest --typecheck",
     "typecheck": "tsc --noEmit",
     "prepare": "simple-git-hooks"
   },

--- a/package/test/index.test-d.ts
+++ b/package/test/index.test-d.ts
@@ -1,0 +1,94 @@
+import type { MaybeError, PackageVersionsInfo, PackageVersionsInfoWithMetadata, ResolvedPackageVersionWithMetadata } from '../../shared/types'
+import type { ResolvedPackageVersion } from '../src'
+import { describe, expectTypeOf, it } from 'vitest'
+import { getLatestVersion, getLatestVersionBatch, getVersions, getVersionsBatch } from '../src'
+
+describe('types', () => {
+  it('latest', () => {
+    expectTypeOf(getLatestVersion('vite@2'))
+      .resolves
+      .toEqualTypeOf<ResolvedPackageVersion>()
+
+    expectTypeOf(getLatestVersion('vite@2', { metadata: true }))
+      .resolves
+      .toEqualTypeOf<ResolvedPackageVersionWithMetadata>()
+
+    expectTypeOf(getLatestVersion('vite@2', { metadata: false }))
+      .resolves
+      .toEqualTypeOf<ResolvedPackageVersion>()
+
+    expectTypeOf(getLatestVersion('vite@2', { throw: true }))
+      .resolves
+      .toEqualTypeOf<ResolvedPackageVersion>()
+
+    expectTypeOf(getLatestVersion('vite@2', { throw: false }))
+      .resolves
+      .toEqualTypeOf<MaybeError<ResolvedPackageVersion>>()
+  })
+
+  it('latest batch', () => {
+    expectTypeOf(getLatestVersionBatch(['vite@2']))
+      .resolves
+      .toEqualTypeOf<ResolvedPackageVersion[]>()
+
+    expectTypeOf(getLatestVersionBatch(['vite@2'], { metadata: true }))
+      .resolves
+      .toEqualTypeOf<ResolvedPackageVersionWithMetadata[]>()
+
+    expectTypeOf(getLatestVersionBatch(['vite@2'], { metadata: false }))
+      .resolves
+      .toEqualTypeOf<ResolvedPackageVersion[]>()
+
+    expectTypeOf(getLatestVersionBatch(['vite@2'], { throw: true }))
+      .resolves
+      .toEqualTypeOf<ResolvedPackageVersion[]>()
+
+    expectTypeOf(getLatestVersionBatch(['vite@2'], { throw: false }))
+      .resolves
+      .toEqualTypeOf<MaybeError<ResolvedPackageVersion>[]>()
+  })
+
+  it('versions', () => {
+    expectTypeOf(getVersions('vite@2'))
+      .resolves
+      .toEqualTypeOf<PackageVersionsInfo>()
+
+    expectTypeOf(getVersions('vite@2', { metadata: true }))
+      .resolves
+      .toEqualTypeOf<PackageVersionsInfoWithMetadata>()
+
+    expectTypeOf(getVersions('vite@2', { metadata: false }))
+      .resolves
+      .toEqualTypeOf<PackageVersionsInfo>()
+
+    expectTypeOf(getVersions('vite@2', { throw: true }))
+      .resolves
+      .toEqualTypeOf<PackageVersionsInfo>()
+
+    expectTypeOf(getVersions('vite@2', { throw: false }))
+      .resolves
+      .toEqualTypeOf<MaybeError<PackageVersionsInfo>>()
+  })
+
+  it('versions batch', () => {
+    expectTypeOf(getVersionsBatch(['vite@2']))
+      .resolves
+      .toEqualTypeOf<PackageVersionsInfo[]>()
+
+    expectTypeOf(getVersionsBatch(['vite@2'], { metadata: true }))
+      .resolves
+      .toEqualTypeOf<PackageVersionsInfoWithMetadata[]>()
+
+    expectTypeOf(getVersionsBatch(['vite@2'], { metadata: false }))
+      .resolves
+      .toEqualTypeOf<PackageVersionsInfo[]>()
+
+    expectTypeOf(getVersionsBatch(['vite@2'], { throw: true }))
+      .resolves
+      .toEqualTypeOf<PackageVersionsInfo[]>()
+
+    expectTypeOf(getVersionsBatch(['vite@2'], { throw: false }))
+      .resolves
+      .toEqualTypeOf<MaybeError<PackageVersionsInfo>[]>()
+  })
+})

--- a/package/test/index.test.ts
+++ b/package/test/index.test.ts
@@ -12,7 +12,7 @@ it.concurrent('latest', async () => {
       lastSynced: expect.any(Number),
     })
 
-  expect(await getLatestVersion('some-private-package@0', { apiEndpoint }))
+  expect(await getLatestVersion('some-private-package@0', { apiEndpoint, throw: false }))
     .toMatchObject({
       name: 'some-private-package@0',
       error: '[GET] \"https://registry.npmjs.org/some-private-package\": 404 Not Found',
@@ -27,7 +27,7 @@ it.concurrent('latest', async () => {
       lastSynced: expect.any(Number),
     })
 
-  expect(await getLatestVersion('some-private-package@0', { apiEndpoint, metadata: true }))
+  expect(await getLatestVersion('some-private-package@0', { apiEndpoint, metadata: true, throw: false }))
     .toMatchObject({
       name: 'some-private-package@0',
       error: '[GET] \"https://registry.npmjs.org/some-private-package\": 404 Not Found',
@@ -53,7 +53,7 @@ it.concurrent('latest', async () => {
       },
     ])
 
-  expect(await getLatestVersionBatch(['vite@5', 'some-private-package@0', 'nuxt@~3.6'], { apiEndpoint, metadata: true }))
+  expect(await getLatestVersionBatch(['vite@5', 'some-private-package@0', 'nuxt@~3.6'], { apiEndpoint, metadata: true, throw: false }))
     .toMatchObject([
       {
         name: 'vite',
@@ -88,15 +88,15 @@ it.concurrent('versions', async () => {
     })
 
   await expect(getVersions('some-private-package', { apiEndpoint }))
+    .rejects
+    .toThrowErrorMatchingInlineSnapshot(`[Error: [GET] "https://registry.npmjs.org/some-private-package": 404 Not Found]`)
+
+  await expect(getVersions('some-private-package', { apiEndpoint, throw: false }))
     .resolves
     .toMatchObject({
       name: 'some-private-package',
       error: '[GET] "https://registry.npmjs.org/some-private-package": 404 Not Found',
     })
-
-  await expect(() => getVersions('some-private-package', { throw: true, apiEndpoint }))
-    .rejects
-    .toThrowErrorMatchingInlineSnapshot(`[Error: [GET] "https://registry.npmjs.org/some-private-package": 404 Not Found]`)
 
   expect(await getVersions('are-we-there-yet', { apiEndpoint, metadata: true }))
     .toMatchObject({
@@ -113,7 +113,7 @@ it.concurrent('versions', async () => {
       lastSynced: expect.any(Number),
     })
 
-  expect(await getVersions('some-private-package', { apiEndpoint, metadata: true }))
+  expect(await getVersions('some-private-package', { apiEndpoint, metadata: true, throw: false }))
     .toMatchObject({
       name: 'some-private-package',
       error: '[GET] "https://registry.npmjs.org/some-private-package": 404 Not Found',

--- a/server/routes/[...pkg].ts
+++ b/server/routes/[...pkg].ts
@@ -1,10 +1,10 @@
-import type { ResolvedPackageVersion } from '../../shared/types'
+import type { ResolvedPackageVersion, ResolvedPackageVersionWithMetadata } from '../../shared/types'
 import semver from 'semver'
 import { fetchPackageManifest } from '../utils/fetch'
 import { handlePackagesQuery } from '../utils/handle'
 
 export default eventHandler(async (event) => {
-  return handlePackagesQuery<ResolvedPackageVersion>(
+  return handlePackagesQuery<ResolvedPackageVersion | ResolvedPackageVersionWithMetadata>(
     event,
     async (spec, query) => {
       const data = await fetchPackageManifest(spec.name, !!query.force)

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -41,10 +41,12 @@ export interface PackageManifestError extends PackageError {
   lastSynced: number
 }
 
-export interface ResolvedPackageVersion extends Partial<PackageVersionMeta> {
+export interface ResolvedPackageVersion {
   name: string
   version: string | null
   specifier: string
   publishedAt: string | null
   lastSynced: number
 }
+
+export interface ResolvedPackageVersionWithMetadata extends ResolvedPackageVersion, PackageVersionMeta {}


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR:

- Improve API return types based on the provided options.
- Corrects the default value of `throw` to `true`, as per the [previous conclusion](https://github.com/antfu/fast-npm-meta/pull/8#issuecomment-2760034490)

### Linked Issues

resolves #13

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
