### PR TITLE
feat: support filtering package versions by `after` date query param

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ curl https://npm.antfu.dev/versions/vite
 }
 ```
 
-### 📦 Get All Versions Published After a Certain Date
+#### 📦 Get All Versions Published After a Certain Date
 
 You can pass the `after` query parameter (ISO 8601 date string or timestamp) to only return versions published after a specific point in time.
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,36 @@ curl https://npm.antfu.dev/versions/vite
 }
 ```
 
+### 📦 Get All Versions Published After a Certain Date
+
+You can pass the `after` query parameter (ISO 8601 date string or timestamp) to only return versions published after a specific point in time.
+
+```sh
+curl "https://npm.antfu.dev/versions/vite?after=2025-01-01T00:00:00Z"
+```
+
+```jsonc
+{
+  "name": "vite",
+  "specifier": "*",
+  "distTags": {
+    "alpha": "6.0.0-alpha.24",
+    "latest": "6.3.0",
+    "previous": "4.5.13",
+    "beta": "6.3.0-beta.2"
+  },
+  "lastSynced": 1744845678674,
+  "versions": [
+    "6.0.7"
+    // ...
+  ],
+  "time": {
+    "6.0.7": "2025-01-02T19:50:46.030Z"
+    // ...
+  }
+}
+```
+
 #### 📦 Get Versions satisfies the Version Range
 
 ```sh

--- a/package/src/api.ts
+++ b/package/src/api.ts
@@ -43,6 +43,12 @@ export interface GetVersionsOptions<
    * @default false
    */
   metadata?: Metadata
+  /**
+   * Only return versions published after this ISO date-time
+   *
+   * @default undefined
+   */
+  after?: string
 }
 
 export interface GetLatestVersionOptions<
@@ -142,6 +148,7 @@ export async function getVersionsBatch<
     options.force ? 'force=true' : '',
     options.loose ? 'loose=true' : '',
     options.metadata ? 'metadata=true' : '',
+    options.after ? `after=${encodeURIComponent(options.after)}` : '',
     throwError ? '' : 'throw=false',
   ].filter(Boolean).join('&')
   if (query)

--- a/server/routes/versions/[...pkg].ts
+++ b/server/routes/versions/[...pkg].ts
@@ -1,5 +1,6 @@
 import type { PackageVersionsInfo, PackageVersionsInfoWithMetadata } from '../../../shared/types'
 import semver from 'semver'
+import { normalizeQueryDate } from '~/utils/date'
 import { fetchPackageManifest } from '../../utils/fetch'
 import { handlePackagesQuery } from '../../utils/handle'
 
@@ -29,6 +30,16 @@ export default eventHandler(async (event) => {
         const tag = manifest.distTags[spec.fetchSpec]
         if (tag) {
           versions = [tag]
+        }
+      }
+
+      if (query.after) {
+        const afterDate = normalizeQueryDate(query.after)
+        if (afterDate) {
+          versions = versions.filter((v) => {
+            const meta = manifest.versionsMeta[v]
+            return meta.time && new Date(meta.time) > afterDate
+          })
         }
       }
 

--- a/server/utils/date.ts
+++ b/server/utils/date.ts
@@ -1,0 +1,24 @@
+/**
+ * This utility helps safely extract a date from query params that may come
+ * in various types. Since query values can be ambiguous or malformed
+ * this function ensures only valid date values are passed to the Date
+ * constructor, preventing "Invalid Date"
+ */
+export function normalizeQueryDate(input: unknown): Date | undefined {
+  let raw: string | number | undefined
+
+  if (Array.isArray(input)) {
+    raw = input[0]
+  }
+  else if (typeof input === 'string' || typeof input === 'number') {
+    raw = input
+  }
+
+  if (raw !== undefined && raw !== null && raw !== '') {
+    const date = new Date(raw)
+    if (!Number.isNaN(date.getTime())) {
+      return date
+    }
+  }
+  return undefined
+}


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

- Add `normalizeQueryDate` utility to parse and validate date values from query params.
- Extend package versions endpoint to support `after` query parameter for returning only versions released after a specific date.
- Updated root README accordingly.

### Linked Issues

Closes #15 

### Additional context

n/a

<!-- e.g. is there anything you'd like reviewers to focus on? -->
