### PR TITLE
fix: handle URL encoding variations for + separator in batch requests

### DIFF
--- a/server/utils/handle.ts
+++ b/server/utils/handle.ts
@@ -13,7 +13,10 @@ export async function handlePackagesQuery<T extends object>(
 
   const throwError = !(query.throw === 'false' || query.throw === false)
 
-  const raw = decodeURIComponent(event.context.params.pkg)
+  // Normalize + separator encoding in batch requests (+ → space → %2B variations)
+  // See: https://github.com/antfu/node-modules-inspector/issues/109
+  const raw = decodeURIComponent(event.context.params.pkg.replace(/%2B/g, '+'))
+    .replace(/ /g, '+')
 
   const specs = raw.split('+').filter(Boolean)
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fix URL encoding issues with + separator in batch requests that cause 400 errors in node-modules-inspector.

### Linked Issues

fixes: https://github.com/antfu/node-modules-inspector/issues/109

### Additional context

Looked through h3 and fast-npm-meta codebases but couldn't find different solution. Open to better approaches if anyone has ideas