### PR TITLE
fix: handle specifier with =

### DIFF
--- a/package/test/index.test.ts
+++ b/package/test/index.test.ts
@@ -76,6 +76,13 @@ it.concurrent('latest', async () => {
         lastSynced: expect.any(Number),
       },
     ])
+
+  expect(await getLatestVersion('vite@=7.0.3', { apiEndpoint, throw: false }))
+    .toMatchObject({
+      name: 'vite',
+      specifier: '=7.0.3',
+      version: '7.0.3',
+    })
 })
 
 it.concurrent('versions', async () => {

--- a/server/routes/[...pkg].ts
+++ b/server/routes/[...pkg].ts
@@ -34,7 +34,7 @@ export default eventHandler(async (event) => {
         })
       }
       else if (spec.type === 'version') {
-        version = spec.fetchSpec
+        version = semver.clean(spec.fetchSpec, true)
         specifier = spec.fetchSpec
       }
       else {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

---

> Please be aware that vibe-coding contributions are **🚫 STRICTLY PROHIBITED**. 
> We are humans behind these open source projects, trying hard to maintain good quality and a healthy community. 
> Not only do vibe-coding contributions pollute the code, but they also drain A LOT of unnecessary energy and time from maintainers and toxify the community and collaboration.
>
> All vibe-coded, AI-generated PRs will be rejected and closed without further notice. In severe cases, your account might be banned organization-wide and reported to GitHub.
>
> **PLEASE SHOW SOME RESPECT** and do not do so.

---

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving and **WHY**, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

- [x] <- Keep this line and put an `x` between the brackts.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving, and "WHY" -->

Currently fast-npm-meta will crash with a specifier that has `=` in it, for example I saw this in the wild with `"@oxc-project/types": "=0.112.0"` in the dependencies of rolldown. The simplest solution is just to use the `clean` fn from semver which is specifically designed to remove this. We can verify that others are doing this too by looking at [the source for npm-pick-manifest](https://github.com/npm/npm-pick-manifest/blob/dfae65d4d237ce242dc3c536aee738d6bdf391b3/lib/index.js#L109)

### Linked Issues

n/a

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
