### PR TITLE
fix: range semver in url properly handled, remove space-plus replacement

### DIFF
--- a/package/test/index.test.ts
+++ b/package/test/index.test.ts
@@ -155,7 +155,6 @@ it.concurrent('batch URL encoding normalization', async () => {
   const testCases = [
     { name: 'normal', url: `${apiEndpoint}/vite@5+vue@3` },
     { name: '%2B encoded', url: `${apiEndpoint}/vite@5%2Bvue@3` },
-    { name: 'space converted', url: `${apiEndpoint}/vite@5%20vue@3` },
   ]
 
   for (const testCase of testCases) {
@@ -184,7 +183,6 @@ it.concurrent('versions URL encoding normalization', async () => {
   const testCases = [
     { name: 'normal', url: `${apiEndpoint}/versions/vite@5+vue@3` },
     { name: '%2B encoded', url: `${apiEndpoint}/versions/vite@5%2Bvue@3` },
-    { name: 'space converted', url: `${apiEndpoint}/versions/vite@5%20vue@3` },
   ]
 
   for (const testCase of testCases) {
@@ -205,4 +203,70 @@ it.concurrent('versions URL encoding normalization', async () => {
         },
       ])
   }
+})
+
+it.concurrent('semver range normalization', async () => {
+  const { fetch: fetchApi } = globalThis
+
+  // Comparators range with/without space
+  const testCases = [
+    {
+      name: 'comparator range with space',
+      url: `${apiEndpoint}/vite@>=5.0.0%20<6.0.0`,
+    },
+    {
+      name: 'comparator range no space',
+      url: `${apiEndpoint}/vite@>=5.0.0<6.0.0`,
+    },
+  ]
+
+  for (const testCase of testCases) {
+    const result = await fetchApi(testCase.url).then(r => r.json())
+    expect(result, `Failed for ${testCase.name} case`).toMatchObject({
+      name: 'vite',
+      specifier: '>=5.0.0 <6.0.0',
+      version: expect.stringMatching(/^5\.\d+\.\d+$/),
+      lastSynced: expect.any(Number),
+      publishedAt: expect.any(String),
+    })
+  }
+
+  // Hyphen range with/without spaces: 5.0.0-5.4.0 → 5.0.0 - 5.4.0
+  const testCasesHyphen = [
+    {
+      name: 'hyphen range without spaces',
+      url: `${apiEndpoint}/vite@5.0.0-5.4.0`,
+    },
+    {
+      name: 'hyphen range with spaces',
+      url: `${apiEndpoint}/vite@5.0.0%20-%205.4.0`,
+    },
+    {
+      name: 'hyphen range with 1 space',
+      url: `${apiEndpoint}/vite@5.0.0-%205.4.0`,
+    },
+    {
+      name: 'hyphen range with 1 space after',
+      url: `${apiEndpoint}/vite@5.0.0%20-5.4.0`,
+    },
+  ]
+
+  for (const testCase of testCasesHyphen) {
+    const result = await fetchApi(testCase.url).then(r => r.json())
+    expect(result, `Failed for ${testCase.name} case`).toMatchObject({
+      name: 'vite',
+      specifier: '5.0.0 - 5.4.0',
+      version: expect.stringMatching(/^5\.[0-4]\.\d+$/),
+    })
+  }
+
+  // Space after @: vite@%20>=5.0.0 → vite@>=5.0.0 (decodes to "vite@ >=5.0.0")
+  const spaceAfterAt = await fetchApi(`${apiEndpoint}/vite@%20>=5.0.0`).then(
+    r => r.json(),
+  )
+  expect(spaceAfterAt, 'space after @').toMatchObject({
+    name: 'vite',
+    specifier: '>=5.0.0',
+    version: expect.stringMatching(/^\d+\.\d+\.\d+$/),
+  })
 })

--- a/server/routes/[...pkg].ts
+++ b/server/routes/[...pkg].ts
@@ -1,61 +1,66 @@
-import type { ResolvedPackageVersion, ResolvedPackageVersionWithMetadata } from '../../shared/types'
+import type {
+  ResolvedPackageVersion,
+  ResolvedPackageVersionWithMetadata,
+} from '../../shared/types'
 import semver from 'semver'
 import { fetchPackageManifest } from '../utils/fetch'
 import { handlePackagesQuery } from '../utils/handle'
 
 export default eventHandler(async (event) => {
-  return handlePackagesQuery<ResolvedPackageVersion | ResolvedPackageVersionWithMetadata>(
-    event,
-    async (spec, query) => {
-      const data = await fetchPackageManifest(spec.name, !!query.force)
+  return handlePackagesQuery<
+    ResolvedPackageVersion | ResolvedPackageVersionWithMetadata
+  >(event, async (spec, query) => {
+    const data = await fetchPackageManifest(spec.name, !!query.force)
 
-      let version: string | null = null
-      let specifier = 'latest'
+    let version: string | null = null
+    let specifier = 'latest'
 
-      if (spec.type === 'tag') {
-        specifier = spec.fetchSpec
-        version = data.distTags[spec.fetchSpec]
-      }
-      else if (spec.type === 'range' && (spec.fetchSpec === '*' || spec.fetchSpec === 'latest')) {
-        version = data.distTags.latest
-        specifier = 'latest'
-      }
-      else if (spec.type === 'range') {
-        specifier = spec.fetchSpec
-        let maxVersion: string | null = data.distTags.latest
-        if (!semver.satisfies(maxVersion, spec.fetchSpec))
-          maxVersion = null
+    if (spec.type === 'tag') {
+      specifier = spec.fetchSpec
+      version = data.distTags[spec.fetchSpec]
+    }
+    else if (
+      spec.type === 'range'
+      && (spec.fetchSpec === '*' || spec.fetchSpec === 'latest')
+    ) {
+      version = data.distTags.latest
+      specifier = 'latest'
+    }
+    else if (spec.type === 'range') {
+      specifier = spec.fetchSpec
+      let maxVersion: string | null = data.distTags.latest
+      if (!semver.satisfies(maxVersion, spec.fetchSpec))
+        maxVersion = null
 
-        Object.keys(data.versionsMeta).forEach((ver) => {
-          if (semver.satisfies(ver, spec.fetchSpec)) {
-            if (!maxVersion || semver.lte(ver, maxVersion))
-              version = ver
-          }
-        })
-      }
-      else if (spec.type === 'version') {
-        version = semver.clean(spec.fetchSpec, true)
-        specifier = spec.fetchSpec
-      }
-      else {
-        throw new Error(`Unsupported spec: ${JSON.stringify(spec)}`)
-      }
+      Object.keys(data.versionsMeta).forEach((ver) => {
+        if (semver.satisfies(ver, spec.fetchSpec)) {
+          if (!maxVersion || semver.lte(ver, maxVersion))
+            version = ver
+        }
+      })
+    }
+    else if (spec.type === 'version') {
+      version = semver.clean(spec.fetchSpec, true)
+      specifier = spec.fetchSpec
+    }
+    else {
+      throw new Error(`Unsupported spec: ${JSON.stringify(spec)}`)
+    }
 
-      const meta = data.versionsMeta[version]
+    const meta = data.versionsMeta[version]
 
-      const result: ResolvedPackageVersion = {
-        name: spec.name,
-        specifier,
-        version,
-        publishedAt: meta.time,
-        lastSynced: data.lastSynced,
-      }
+    const result: ResolvedPackageVersion = {
+      name: spec.name,
+      specifier,
+      version,
+      publishedAt: meta?.time || undefined,
+      lastSynced: data.lastSynced,
+    }
 
-      if (query.metadata) {
-        Object.assign(result, meta)
-      }
+    if (query.metadata) {
+      Object.assign(result, meta)
+    }
 
-      return result
-    },
-  )
+    return result
+  })
 })

--- a/server/utils/handle.ts
+++ b/server/utils/handle.ts
@@ -15,10 +15,9 @@ export async function handlePackagesQuery<T extends object>(
 
   const throwError = !(query.throw === 'false' || query.throw === false)
 
-  // Normalize + separator encoding in batch requests (+ → space → %2B variations)
+  // Normalize + separator encoding in batch requests (+ → %2B variations)
   // See: https://github.com/antfu/node-modules-inspector/issues/109
   const raw = decodeURIComponent(event.context.params.pkg.replace(/%2B/g, '+'))
-    .replace(/ /g, '+')
 
   const specs = raw.split('+').filter(Boolean)
 
@@ -30,10 +29,14 @@ export async function handlePackagesQuery<T extends object>(
     let parsedSpec: ParsedSpec
     try {
       // Throws if the package name is invalid
-      parsedSpec = parsePackage(spec)
+      parsedSpec = parsePackage(normalizeSemverRange(spec))
     }
     catch (error) {
-      const result: PackageError = { status: DEFAULT_ERROR_STATUS, name: spec, error: retrieveErrorMessage(error) }
+      const result: PackageError = {
+        status: DEFAULT_ERROR_STATUS,
+        name: spec,
+        error: retrieveErrorMessage(error),
+      }
       if (throwError) {
         return createError({
           status: result.status,
@@ -45,7 +48,11 @@ export async function handlePackagesQuery<T extends object>(
     }
 
     if (!parsedSpec.name) {
-      const result: PackageError = { status: DEFAULT_ERROR_STATUS, name: spec, error: `Invalid package specifier: ${spec}` }
+      const result: PackageError = {
+        status: DEFAULT_ERROR_STATUS,
+        name: spec,
+        error: `Invalid package specifier: ${spec}`,
+      }
       if (throwError) {
         return createError({
           status: result.status,
@@ -60,19 +67,21 @@ export async function handlePackagesQuery<T extends object>(
   }
 
   if (validSpecs.length) {
-    await Promise.allSettled(validSpecs.map(async ([idx, parsedSpec]) =>
-      handler(parsedSpec, query)
-        .then((result) => {
-          results[idx] = result
-        })
-        .catch((error) => {
-          results[idx] = {
-            status: error.status ?? DEFAULT_ERROR_STATUS,
-            name: parsedSpec.raw,
-            error: retrieveErrorMessage(error),
-          }
-        }),
-    ))
+    await Promise.allSettled(
+      validSpecs.map(async ([idx, parsedSpec]) =>
+        handler(parsedSpec, query)
+          .then((result) => {
+            results[idx] = result
+          })
+          .catch((error) => {
+            results[idx] = {
+              status: error.status ?? DEFAULT_ERROR_STATUS,
+              name: parsedSpec.raw,
+              error: retrieveErrorMessage(error),
+            }
+          }),
+      ),
+    )
   }
 
   if (throwError) {
@@ -97,4 +106,19 @@ function retrieveErrorMessage(error: unknown): string {
     return error.message as string
   }
   return error ? String(error) : 'Unknown error'
+}
+
+function normalizeSemverRange(rangeSpec: string): string {
+  return (
+    rangeSpec
+      // Remove possible space after @: pkg@ >1 → pkg@>1
+      .replace(/@\s+/g, '@')
+      // Normalize Hyphens: "1- 3", "1 -3", "1-3" → "1 - 3"
+      .replace(/(?<=[0-9x*])\s*-\s*(?=[0-9x*])/gi, ' - ')
+      // Normalize Comparators: "pkg@>1<3" → "pkg@>1 <3"
+      .replace(/(?<=[0-9x*])(?=[<>=^~])/gi, ' ')
+      // Collapse multiple spaces
+      .replace(/\s+/g, ' ')
+      .trim()
+  )
 }


### PR DESCRIPTION
- [x] <- Keep this line and put an `x` between the brackts.

### Description

- Removed regression impemented in https://github.com/antfu/fast-npm-meta/pull/18 . Replacing " " (spaces) with "+" (plus)
 caused an issue when valid semver range versions, which SHOULD have space to be properly handled by internal library (like `pkg@>1 <3` or `pkg@1- 3`) were mistakenly split into separate packages by injecting "+".
- Added logic to properly handle any incoming range semver even with/without space(s):
  - `pkg@ >1` -> `pkg@>1`
  - `pkg@>1<3` -> `pkg@>1 <3`
  - `pkg@1-3` -> `pkg@1 - 3`
  - `pkg@1- 3` -> `pkg@1 - 3`
  - `pkg@1 -3` -> `pkg@1 - 3`
- Added tests to cover newly added logic on range versions handling

### Linked Issues

fixes https://github.com/antfu/fast-npm-meta/issues/31

### Additional context

This will fix an important regression bug and also is very important for the npmx project. It relies on this package in terms of version resolution.
