### PR TITLE
fix: preserve multiple hyphens inside the identifier

### DIFF
--- a/package/test/index.test.ts
+++ b/package/test/index.test.ts
@@ -383,4 +383,16 @@ describe.concurrent('complex package names, complex versions', async () => {
       lastSynced: expect.any(Number),
     })
   })
+
+  it('package with multiple hyphens inside the identifier', async () => {
+    const result = await fetchApi(
+      `${apiEndpoint}/@graphql-codegen/cli@7.0.0-alpha-20260308111732-1c74ce2a5d8333d4f725c438ff9b6bbbf3e2386e`,
+    ).then(r => r.json())
+    expect(result).toMatchObject({
+      name: '@graphql-codegen/cli',
+      specifier: '7.0.0-alpha-20260308111732-1c74ce2a5d8333d4f725c438ff9b6bbbf3e2386e',
+      version: '7.0.0-alpha-20260308111732-1c74ce2a5d8333d4f725c438ff9b6bbbf3e2386e',
+      lastSynced: expect.any(Number),
+    })
+  })
 })

--- a/server/utils/handle.ts
+++ b/server/utils/handle.ts
@@ -126,7 +126,13 @@ function normalizeSemverRange(spec: string): string {
     .replace(/(?<=\d)-(?=\d)/g, (match, offset, str) => {
       // If preceded by a full x.y.z version, it's a pre-release tag - do not add spaces not to break it
       const before = str.slice(0, offset)
-      return /\d+\.\d+\.\d+$/.test(before) ? match : ' - '
+
+      // Keep the hyphen if we are right after a full x.y.z (start of a pre-release),
+      // OR we are already inside a pre-release (a previous "-" exists)
+      // Otherwise it is a range hyphen and we want spaces.
+      return /\d+\.\d+\.\d+$/.test(before) || before.includes('-')
+        ? match
+        : ' - '
     })
     // Normalize Comparators: "pkg@>1<3" → "pkg@>1 <3"
     .replace(/(?<=[0-9x*])(?=[<>=^~])/gi, ' ')


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

---

> Please be aware that vibe-coding contributions are **🚫 STRICTLY PROHIBITED**. 
> We are humans behind these open source projects, trying hard to maintain good quality and a healthy community. 
> Not only do vibe-coding contributions pollute the code, but they also drain A LOT of unnecessary energy and time from maintainers and toxify the community and collaboration.
>
> All vibe-coded, AI-generated PRs will be rejected and closed without further notice. In severe cases, your account might be banned organization-wide and reported to GitHub.
>
> **PLEASE SHOW SOME RESPECT** and do not do so.

---

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving and **WHY**, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

- [x] <- Keep this line and put an `x` between the brackets.

### Description

Preserves multiple hyphens inside the identifier, as it is valid on npm

### Linked Issues

fixes #35

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

https://github.com/npmx-dev/npmx.dev/issues/1968