### PR TITLE
fix: return 404 when requesting not existing exact version

### DIFF
--- a/package/test/index.test.ts
+++ b/package/test/index.test.ts
@@ -108,6 +108,17 @@ it.concurrent('latest', async () => {
     specifier: '=7.0.3',
     version: '7.0.3',
   })
+
+  expect(
+    await getLatestVersion('axios@150.150.150', { apiEndpoint, throw: false }),
+  ).toMatchObject({
+    name: 'axios@150.150.150',
+    error: 'Version 150.150.150 of package axios not found',
+  })
+
+  await expect(
+    getLatestVersion('axios@150.150.150', { apiEndpoint }),
+  ).rejects.toThrow('Version 150.150.150 of package axios not found')
 })
 
 it.concurrent('versions', async () => {
@@ -361,13 +372,13 @@ describe.concurrent('complex package names, complex versions', async () => {
   })
 
   it('multi-word package name with pre release version with hyphen in specifier', async () => {
-    const result = await fetchApi(`${apiEndpoint}/${pkgName}@1.0.0-pr.6`).then(
+    const result = await fetchApi(`${apiEndpoint}/${pkgName}@1.0.0-rc.4`).then(
       r => r.json(),
     )
     expect(result).toMatchObject({
       name: pkgName,
-      specifier: '1.0.0-pr.6',
-      version: '1.0.0-pr.6',
+      specifier: '1.0.0-rc.4',
+      version: '1.0.0-rc.4',
       lastSynced: expect.any(Number),
     })
   })

--- a/server/routes/[...pkg].ts
+++ b/server/routes/[...pkg].ts
@@ -42,6 +42,12 @@ export default eventHandler(async (event) => {
     else if (spec.type === 'version') {
       version = semver.clean(spec.fetchSpec, true)
       specifier = spec.fetchSpec
+      if (version && !data.versionsMeta[version]) {
+        throw createError({
+          status: 404,
+          message: `Version ${version} of package ${spec.name} not found`,
+        })
+      }
     }
     else {
       throw new Error(`Unsupported spec: ${JSON.stringify(spec)}`)

--- a/server/utils/handle.ts
+++ b/server/utils/handle.ts
@@ -77,7 +77,7 @@ export async function handlePackagesQuery<T extends object>(
           })
           .catch((error) => {
             results[idx] = {
-              status: error.status ?? DEFAULT_ERROR_STATUS,
+              status: error.statusCode ?? error.status ?? DEFAULT_ERROR_STATUS,
               name: parsedSpec.raw,
               error: retrieveErrorMessage(error),
             }


### PR DESCRIPTION
## Summary

This PR is relate to  the PR I made in npmx:  https://github.com/npmx-dev/npmx.dev/pull/2383

Fixes a bug where requesting a non-existent exact  version (e.g. `axios@150.150.150`) returned HTTP 200 and echoed back the version string instead of returning a 404.

## Changes

- `routes/[...pkg].ts` 
when `spec.type === 'version'`, check the version exists in `data.versionsMeta` and throw a 404 if not.
- `handle.ts` 
 fix batch error status propagation: read `error.statusCode ?? error.status` so  errors are not downgraded to 400.
- `index.test.ts` 
 add test for non-existent exact version,  update pre-release  test to use a version that actually exists in the registry.
 