### PR TITLE
docs(skill): align SKILL.md with Anthropic Skills best practices

### DIFF
--- a/skills/fast-npm-meta/SKILL.md
+++ b/skills/fast-npm-meta/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: fast-npm-meta
-description: Get npm package metadata
-license: MIT
+description: Queries npm package metadata via the fast-npm-meta CLI — resolves package versions, dist-tags, publish dates, engine requirements, and version range specifiers. Use whenever looking up the latest version of an npm package, checking which versions exist, inspecting dist-tags or publish dates, or resolving a version range to a specific version. Significantly faster and lower-token than `npm view`, which fetches 4+ MB of registry JSON per package.
 ---
 
 # fast-npm-meta CLI


### PR DESCRIPTION
## Summary
- Rewrite the `description` in `skills/fast-npm-meta/SKILL.md` to follow [Anthropic's Skill authoring best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices): third person, concrete capabilities (versions, dist-tags, publish dates, engine requirements, ranges), explicit *when-to-use* trigger, and a discovery hook against `npm view`.
- Drop the non-schema `license: MIT` field from the frontmatter; license info already lives in the repo `LICENSE`.

## Test plan
- [x] Validated with `skill-creator/scripts/quick_validate.py` → "Skill is valid!"
- [x] Frontmatter fields stay within limits (`name` ≤ 64 chars, `description` ≤ 1024 chars).

🤖 Generated with [Claude Code](https://claude.com/claude-code)