### PR TITLE
feat: add Dockerfile for self-hosting

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+.output
+.nitro
+.netlify
+.git
+*.md
+package/dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM node:22-slim AS base
+
+RUN corepack enable && corepack prepare pnpm@10.33.2 --activate
+WORKDIR /app
+
+# -- install dependencies --
+FROM base AS deps
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY server/package.json server/
+COPY package/package.json package/
+RUN pnpm install --frozen-lockfile
+
+# -- build --
+FROM deps AS build
+ARG GIT_REVISION=""
+COPY . .
+ENV NITRO_PRESET=node-server
+ENV GIT_REVISION=${GIT_REVISION}
+RUN pnpm -C server run build
+
+# -- production image --
+FROM node:22-slim AS runtime
+WORKDIR /app
+COPY --from=build /app/server/.output .output
+
+ENV HOST=0.0.0.0
+ENV PORT=3000
+EXPOSE 3000
+
+CMD ["node", ".output/server/index.mjs"]

--- a/README.md
+++ b/README.md
@@ -430,6 +430,25 @@ The tool does not require any preliminary configuration to work, but you can ove
 
 For more information, follow [the official Nitro guides](https://nitro.build/deploy/runtimes/node#environment-variables).
 
+## Docker
+
+```bash
+# Build
+docker build -t fast-npm-meta --build-arg GIT_REVISION=$(git rev-parse HEAD) .
+
+# Run
+docker run -p 3000:3000 fast-npm-meta
+```
+
+Environment variables:
+
+| Variable | Description | Default |
+|---|---|---|
+| `PORT` | Server port | `3000` |
+| `NITRO_APP_CACHE_TIMEOUT` | Cache timeout (ms) | `''` |
+| `NITRO_APP_CACHE_TIMEOUT_FORCE` | Force cache timeout (ms) | `''` |
+| `NITRO_APP_REGISTRY_URL` | npm registry URL | `https://registry.npmjs.org/` |
+
 ## Sponsors
 
 <p align="center">

--- a/server/nitro.config.ts
+++ b/server/nitro.config.ts
@@ -1,11 +1,20 @@
 import { execSync } from 'node:child_process'
 
 const repoUrl = 'https://github.com/antfu/fast-npm-meta'
-const revision = execSync('git rev-parse HEAD').toString().trim()
+// eslint-disable-next-line node/prefer-global/process
+const revision = process.env.GIT_REVISION || (() => {
+  try {
+    return execSync('git rev-parse HEAD').toString().trim()
+  }
+  catch {
+    return 'unknown'
+  }
+})()
 
 // https://nitro.build/config
 export default defineNitroConfig({
-  preset: 'netlify_edge',
+  // eslint-disable-next-line node/prefer-global/process
+  preset: process.env.NITRO_PRESET as any || 'netlify_edge',
 
   storage: {
     manifest: {


### PR DESCRIPTION
- Add multi-stage Dockerfile (node-server preset)
- Add .dockerignore
- Allow overriding git revision and Nitro preset via env vars
- Document Docker usage in README

Closes #19

### 🔗 Linked issue

resolves #19

### 🔄 Context

Currently the server is hardcoded to the `netlify_edge` preset with no official way to self-host. Users who want to deploy on their own infrastructure need a Docker image.

### 📚 Description

Add a multi-stage Dockerfile that builds the server with the `node-server` Nitro preset, producing a minimal production image containing only Node.js and the compiled `.output` directory.

Changes:
- **Dockerfile**: 3-stage build (deps → build → runtime), final image based on `node:22-slim`
- **.dockerignore**: exclude `node_modules`, `.git`, `.output`, etc.
- **server/nitro.config.ts**: allow `NITRO_PRESET` and `GIT_REVISION` env var overrides, with try-catch fallback for `git rev-parse` in environments without `.git`
- **README.md**: add Docker build & run instructions with environment variable reference