### PR TITLE
feat: support JSR packages via `jsr:` prefix

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+.output
+.nitro
+.netlify
+.git
+*.md
+package/dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM node:22-slim AS base
+
+RUN corepack enable && corepack prepare pnpm@10.33.2 --activate
+WORKDIR /app
+
+# -- install dependencies --
+FROM base AS deps
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY server/package.json server/
+COPY package/package.json package/
+RUN pnpm install --frozen-lockfile
+
+# -- build --
+FROM deps AS build
+ARG GIT_REVISION=""
+COPY . .
+ENV NITRO_PRESET=node-server
+ENV GIT_REVISION=${GIT_REVISION}
+RUN pnpm -C server run build
+
+# -- production image --
+FROM node:22-slim AS runtime
+WORKDIR /app
+COPY --from=build /app/server/.output .output
+
+ENV HOST=0.0.0.0
+ENV PORT=3000
+EXPOSE 3000
+
+CMD ["node", ".output/server/index.mjs"]

--- a/README.md
+++ b/README.md
@@ -430,6 +430,25 @@ The tool does not require any preliminary configuration to work, but you can ove
 
 For more information, follow [the official Nitro guides](https://nitro.build/deploy/runtimes/node#environment-variables).
 
+## Docker
+
+```bash
+# Build
+docker build -t fast-npm-meta --build-arg GIT_REVISION=$(git rev-parse HEAD) .
+
+# Run
+docker run -p 3000:3000 fast-npm-meta
+```
+
+Environment variables:
+
+| Variable | Description | Default |
+|---|---|---|
+| `PORT` | Server port | `3000` |
+| `NITRO_APP_CACHE_TIMEOUT` | Cache timeout (ms) | `''` |
+| `NITRO_APP_CACHE_TIMEOUT_FORCE` | Force cache timeout (ms) | `''` |
+| `NITRO_APP_REGISTRY_URL` | npm registry URL | `https://registry.npmjs.org/` |
+
 ## Sponsors
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -154,6 +154,25 @@ Returns an array of objects:
 ]
 ```
 
+## JSR Registry Support
+
+ Packages from [JSR](https://jsr.io) can be queried using the `jsr:` prefix:
+
+ ```
+ GET /jsr:@luca/flag
+ GET /versions/jsr:@luca/flag
+ ```
+
+ Batching with npm packages is supported:
+
+ ```
+ GET /vite+jsr:@luca/flag+vue
+ ```
+
+ The `jsr:@scope/name` prefix is automatically resolved to `@jsr/scope__name`
+ on the JSR npm-compatible registry (`https://npm.jsr.io/`).
+
+<!-- eslint-disable-next-line markdown/heading-increment -->
 #### 📦 Get Extra Metadata
 
 You can pass `?metadata=true` to get additional metadata about the package, such as `engines`, `deprecated`, etc.

--- a/server/nitro.config.ts
+++ b/server/nitro.config.ts
@@ -1,11 +1,20 @@
 import { execSync } from 'node:child_process'
 
 const repoUrl = 'https://github.com/antfu/fast-npm-meta'
-const revision = execSync('git rev-parse HEAD').toString().trim()
+// eslint-disable-next-line node/prefer-global/process
+const revision = process.env.GIT_REVISION || (() => {
+  try {
+    return execSync('git rev-parse HEAD').toString().trim()
+  }
+  catch {
+    return 'unknown'
+  }
+})()
 
 // https://nitro.build/config
 export default defineNitroConfig({
-  preset: 'netlify_edge',
+  // eslint-disable-next-line node/prefer-global/process
+  preset: process.env.NITRO_PRESET as any || 'netlify_edge',
 
   storage: {
     manifest: {

--- a/server/routes/[...pkg].ts
+++ b/server/routes/[...pkg].ts
@@ -9,8 +9,9 @@ import { handlePackagesQuery } from '../utils/handle'
 export default eventHandler(async (event) => {
   return handlePackagesQuery<
     ResolvedPackageVersion | ResolvedPackageVersionWithMetadata
-  >(event, async (spec, query) => {
-    const data = await fetchPackageManifest(spec.name, !!query.force)
+  >(event, async (spec, query, options) => {
+    const data = await fetchPackageManifest(spec.name, !!query.force, options?.registry)
+    const name = options?.displayName || spec.name
 
     let version: string | null = null
     let specifier = 'latest'
@@ -56,7 +57,7 @@ export default eventHandler(async (event) => {
     const meta = data.versionsMeta[version]
 
     const result: ResolvedPackageVersion = {
-      name: spec.name,
+      name,
       specifier,
       version,
       publishedAt: meta?.time || undefined,

--- a/server/utils/fetch.ts
+++ b/server/utils/fetch.ts
@@ -58,7 +58,7 @@ async function _fetchPackageManifest(name: string, registry: string, userAgent: 
 const CACHE_TIMEOUT = /* 15min */ 1000 * 60 * 15
 const CACHE_TIMEOUT_FORCE = /* 30sec */ 1000 * 30
 
-export async function fetchPackageManifest(name: string, force = false) {
+export async function fetchPackageManifest(name: string, force = false, registry?: string) {
   // Short-term cache, another request in progress
   if (promiseCache.has(name)) {
     return promiseCache.get(name)
@@ -84,7 +84,7 @@ export async function fetchPackageManifest(name: string, force = false) {
     }
   }
 
-  const registryUrl = config.app.registryUrl || REGISTRY
+  const registryUrl = registry || config.app.registryUrl || REGISTRY
   const registryUserAgent = config.app.registryUserAgent || USER_AGENT
   const promise = _fetchPackageManifest(name, registryUrl, registryUserAgent)
     .then(async (res) => {

--- a/server/utils/handle.ts
+++ b/server/utils/handle.ts
@@ -4,12 +4,19 @@ import type { QueryObject } from 'ufo'
 import type { MaybeError, PackageError } from '../../shared/types'
 import { createError, getQuery } from 'h3'
 import parsePackage from 'npm-package-arg'
+import { resolveJsrSpec } from './jsr'
 
 const DEFAULT_ERROR_STATUS = 400
 
+export interface ResolvedSpec {
+  spec: ParsedSpec
+  registry?: string
+  displayName?: string
+}
+
 export async function handlePackagesQuery<T extends object>(
   event: H3Event<EventHandlerRequest>,
-  handler: (spec: ParsedSpec, query: QueryObject) => Promise<T>,
+  handler: (spec: ParsedSpec, query: QueryObject, options?: { registry?: string, displayName?: string }) => Promise<T>,
 ): Promise<MaybeError<T> | MaybeError<T>[] | H3Error> {
   const query = getQuery(event)
 
@@ -24,14 +31,20 @@ export async function handlePackagesQuery<T extends object>(
   const specs = raw.split('+').map(s => decodeURIComponent(s)).filter(Boolean)
 
   // Record the spec index to keep the result order consistent.
-  const validSpecs: [idx: number, ParsedSpec][] = []
+  const validSpecs: [idx: number, ResolvedSpec][] = []
   const results = Array.from<MaybeError<T>>({ length: specs.length })
 
   for (const [idx, spec] of specs.entries()) {
     let parsedSpec: ParsedSpec
+    let registry: string | undefined
+    let displayName: string | undefined
+
+    // Detect jsr: prefix
+    const jsrSpec = resolveJsrSpec(spec)
+    const specToParse = jsrSpec ? jsrSpec.registryName : spec
     try {
       // Throws if the package name is invalid
-      parsedSpec = parsePackage(normalizeSemverRange(spec))
+      parsedSpec = parsePackage(normalizeSemverRange(specToParse))
     }
     catch (error) {
       const result: PackageError = {
@@ -64,14 +77,18 @@ export async function handlePackagesQuery<T extends object>(
       results[idx] = result
       continue
     }
+    if (jsrSpec) {
+      registry = jsrSpec.registry
+      displayName = jsrSpec.displayName
+    }
 
-    validSpecs.push([idx, parsedSpec])
+    validSpecs.push([idx, { spec: parsedSpec, registry, displayName }])
   }
 
   if (validSpecs.length) {
     await Promise.allSettled(
-      validSpecs.map(async ([idx, parsedSpec]) =>
-        handler(parsedSpec, query)
+      validSpecs.map(async ([idx, { spec: parsedSpec, registry, displayName }]) =>
+        handler(parsedSpec, query, { registry, displayName })
           .then((result) => {
             results[idx] = result
           })

--- a/server/utils/jsr.ts
+++ b/server/utils/jsr.ts
@@ -1,0 +1,34 @@
+const JSR_REGISTRY = 'https://npm.jsr.io/'
+const JSR_PREFIX = 'jsr:'
+
+export interface ResolvedPackageSpec {
+  /** Resolved package name for registry lookup (e.g. @jsr/luca__flag) */
+  registryName: string
+  /** Original display name (e.g. @luca/flag) */
+  displayName: string
+  /** Registry URL to use */
+  registry?: string
+}
+
+/**
+ * Detect `jsr:` prefix and convert to npm-compat name.
+ * e.g. `jsr:@luca/flag` → `@jsr/luca__flag` on `https://npm.jsr.io/`
+ */
+export function resolveJsrSpec(raw: string): ResolvedPackageSpec | null {
+  if (!raw.startsWith(JSR_PREFIX))
+    return null
+
+  const jsrName = raw.slice(JSR_PREFIX.length)
+
+  // JSR packages must be scoped: @scope/name
+  const match = jsrName.match(/^@([^/]+)\/(.+)$/)
+  if (!match)
+    return null
+
+  const [, scope, name] = match
+  return {
+    registryName: `@jsr/${scope}__${name}`,
+    displayName: jsrName,
+    registry: JSR_REGISTRY,
+  }
+}


### PR DESCRIPTION
### 🔗 Linked issue

resolves #22

### 🔄 Context

JSR provides an npm-compatible registry at `https://npm.jsr.io/`, but there's currently no way to query JSR packages through fast-npm-meta without changing the global `REGISTRY_URL` (which would break npm lookups).

### 📚 Description

Add a `jsr:` prefix that automatically routes requests to the JSR npm-compatible registry.

- `jsr:@scope/name` is resolved to `@jsr/scope__name` on `https://npm.jsr.io/`
- Batching with npm packages works: `/vite+jsr:@luca/flag+vue`
- Response returns the original JSR name (e.g. `@luca/flag`) instead of the internal `@jsr/scope__name`

Changes:
- New `server/utils/jsr.ts` — prefix detection and name conversion
- `server/utils/fetch.ts` — add optional `registry` param to `fetchPackageManifest`
- `server/utils/handle.ts` — detect `jsr:` prefix before parsing, pass registry info to handler
- `server/routes/[...pkg].ts` and `server/routes/versions/[...pkg].ts` — use display name and registry from options
- `README.md` — document JSR usage